### PR TITLE
Add DockerOpts to docker's installation

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -157,4 +157,8 @@ func PrepareFiles(configFilePath, dockerBinPath, keyFilePath, certFilePath strin
 		Logger.Printf("Override 'TutumUUID' from command line flag: %s\n", *FlagTutumUUID)
 		Conf.TutumUUID = *FlagTutumUUID
 	}
+	if *FlagDockerOpts!= "" {
+		Logger.Printf("Override 'DockerOpts' from command line flag: %s\n", *FlagDockerOpts)
+		Conf.DockerOpts = *FlagDockerOpts
+	}
 }

--- a/agent/config.go
+++ b/agent/config.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	TutumHost      string
 	TutumToken     string
 	TutumUUID      string
+	DockerOpts     string
 }
 
 func ParseFlag() {
@@ -43,7 +44,8 @@ func ParseFlag() {
 			"          DockerHost=\"xxx\"\n",
 			"          TutumHost=\"xxx\"\n",
 			"          TutumToken=\"xxx\"\n",
-			"          TutumUUID=\"xxx\"\n")
+			"          TutumUUID=\"xxx\"\n",
+			"          DockerOpts=\"xxx\"\n")
 	}
 	flag.Parse()
 
@@ -85,6 +87,8 @@ func SetConfigFile(configFilePath string) {
 					Conf.TutumToken = value
 				} else if strings.ToLower(key) == strings.ToLower("TutumUUID") {
 					Conf.TutumUUID = value
+				} else if strings.ToLower(key) == strings.ToLower("DockerOpts") {
+					Conf.DockerOpts = value
 				} else {
 					fmt.Fprintf(os.Stderr, "Unsupported item \"%s\" in \"tutum-agent set\" command\n", key)
 					os.Exit(1)


### PR DESCRIPTION
This should handle `DockerOpts` as `StartDocker` function can manage them. What do you think, @tifayuki ?